### PR TITLE
Update PUT routes (#9)

### DIFF
--- a/server/code/resources/grade_sheet_maneuvers.py
+++ b/server/code/resources/grade_sheet_maneuvers.py
@@ -22,24 +22,23 @@ class GradeSheetManeuver(Resource):
 
         # parse request
         parser = reqparse.RequestParser()
-        parser.add_argument('grade_sheet_maneuver_id')
-        parser.add_argument('grade')
+        parser.add_argument('grade', type=int)
         parser.add_argument('comments')
 
         # get data from parser arguments
-        data = parser.parse_args()
+        args = parser.parse_args()
 
         # query for grade_sheet_maneuver
         grade_sheet_maneuver = GradeSheetManeuverModel.objects(grade_sheet_maneuver_id=grade_sheet_maneuver_id).first()
 
         # update record or return 409 (conflict)
         try:
-            grade_sheet_maneuver.update(
-                **{
-                    'grade': data['grade'],
-                    'comments': data['comments']
-                }
-            )
+            # find args that exist and are different
+            grade_sheet_maneuver.update(**{k: args[k] for k in args if (args[k] is not None) & (args[k] != grade_sheet_maneuver[k])})
             return {'message': 'Grade sheet maneuver successfully updated'}
-        except:
-            return {'message': 'Grade sheet maneuver not updated'}, 409
+        except Exception as e:
+            return {
+                        'message': 'Grade sheet maneuver not updated',
+                        'error': str(e)
+                    }, 409
+

--- a/server/code/resources/grade_sheets.py
+++ b/server/code/resources/grade_sheets.py
@@ -1,5 +1,5 @@
 # python imports
-from flask_restful import Resource, reqparse
+from flask_restful import Resource, reqparse, inputs
 
 # project imports
 from models.grade_sheet_maneuvers import GradeSheetManeuverModel
@@ -31,7 +31,7 @@ class GradeSheet(Resource):
 
         # parse request
         parser = reqparse.RequestParser()
-        parser.add_argument('date')
+        parser.add_argument('date', type=inputs.date)
         parser.add_argument('grade')
         parser.add_argument('status')
         parser.add_argument('comments')
@@ -46,9 +46,9 @@ class GradeSheet(Resource):
         try:
             # find args that exist and are different
             grade_sheet.update(**{k: args[k] for k in args if (args[k] is not None) & (args[k] != grade_sheet[k])})
-            return {'message': 'Grade sheet maneuver successfully updated'}
+            return {'message': 'Grade sheet successfully updated'}
         except Exception as e:
             return {
-                        'message': 'Grade sheet maneuver not updated',
+                        'message': 'Grade sheet not updated',
                         'error': str(e)
                     }, 409

--- a/server/code/resources/grade_sheets.py
+++ b/server/code/resources/grade_sheets.py
@@ -1,5 +1,5 @@
 # python imports
-from flask_restful import Resource
+from flask_restful import Resource, reqparse
 
 # project imports
 from models.grade_sheet_maneuvers import GradeSheetManeuverModel
@@ -25,3 +25,30 @@ class GradeSheet(Resource):
         if grade_sheet:
             return {'grade_sheet': grade_sheet}
         return {'message': 'Grade sheet not found'}, 404
+
+
+    def put(self, grade_sheet_id):
+
+        # parse request
+        parser = reqparse.RequestParser()
+        parser.add_argument('date')
+        parser.add_argument('grade')
+        parser.add_argument('status')
+        parser.add_argument('comments')
+
+        # get data from parser arguments
+        args = parser.parse_args()
+
+        # query for grade_sheet_maneuver
+        grade_sheet = GradeSheetModel.objects(grade_sheet_id=grade_sheet_id).first()
+
+        # update record or return 409 (conflict)
+        try:
+            # find args that exist and are different
+            grade_sheet.update(**{k: args[k] for k in args if (args[k] is not None) & (args[k] != grade_sheet[k])})
+            return {'message': 'Grade sheet maneuver successfully updated'}
+        except Exception as e:
+            return {
+                        'message': 'Grade sheet maneuver not updated',
+                        'error': str(e)
+                    }, 409


### PR DESCRIPTION
In this PR, I:
- edited PUT method for `grade_sheet`
- added PUT method for `grade_sheet_maneuver`

In both cases, I added logic for the request parser to update fields
a) that are present in the request
b) whose value is different than the datbase record field value

For the `grade_sheet_maneuver` PUT method, currently it only works for a single maneuver. For the mass update process, a loop will have to be written on the frontend in order to send requests for each maneuver to be saved.